### PR TITLE
Improve encoding performance

### DIFF
--- a/bench.ts
+++ b/bench.ts
@@ -21,7 +21,12 @@ const inputImage = {
 
 const suite = new benchmark.Suite();
 
-suite.add('RGBA6666', () => {
+suite.add('RGBA8888', () => {
+  imageCodecTxi.encode(inputImage, {
+    rle: 'auto',
+    outputFormat: imageCodecTxi.TXIOutputFormat.RGBA8888,
+  });
+}).add('RGBA6666', () => {
   imageCodecTxi.encode(inputImage, {
     rle: 'auto',
     outputFormat: imageCodecTxi.TXIOutputFormat.RGBA6666,

--- a/bench.ts
+++ b/bench.ts
@@ -1,0 +1,50 @@
+import fs from 'fs';
+
+import benchmark from 'benchmark';
+import { PNG } from 'pngjs';
+
+// tslint:disable-next-line:import-name
+import * as imageCodecTxi from '.';
+import { join } from 'path';
+
+const inputPNG = PNG.sync.read(
+  fs.readFileSync(
+    join(__dirname, 'src', '__test__', 'transparency-rgba.png'),
+  ),
+);
+
+const inputImage = {
+  data: new Uint8ClampedArray(inputPNG.data),
+  width: inputPNG.width,
+  height: inputPNG.height,
+};
+
+const suite = new benchmark.Suite();
+
+suite.add('RGBA6666', () => {
+  imageCodecTxi.encode(inputImage, {
+    rle: 'auto',
+    outputFormat: imageCodecTxi.TXIOutputFormat.RGBA6666,
+  });
+})
+.add('RGB565', () => {
+  imageCodecTxi.encode(inputImage, {
+    rle: 'auto',
+    outputFormat: imageCodecTxi.TXIOutputFormat.RGB565,
+  });
+})
+.add('A8', () => {
+  imageCodecTxi.encode(inputImage, {
+    rle: 'auto',
+    outputFormat: imageCodecTxi.TXIOutputFormat.A8,
+  });
+})
+.on('cycle', (event: any) => {
+  console.log(String(event.target));
+  console.log(`${(event.target.stats.mean * 1000).toFixed(2)} ms/run`);
+})
+.on('error', (event: any) => {
+  console.error(`Error running ${event.target.name}:`);
+  console.error(event.target.error);
+})
+.run({ async: true });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "build": "rm -rf lib mod && tsc -p tsconfig.build.json && tsc -p tsconfig.module.json",
     "lint": "tslint -c tslint.json -p tsconfig.json",
     "test": "npm run lint && jest",
-    "prepublishOnly": "npm run test && npm run build"
+    "prepublishOnly": "npm run test && npm run build",
+    "benchmark": "ts-node bench.ts"
   },
   "devDependencies": {
     "@types/benchmark": "^1.0.31",
@@ -30,6 +31,7 @@
     "microtime": "^2.1.8",
     "pngjs": "^3.3.3",
     "ts-jest": "^23.1.4",
+    "ts-node": "^7.0.1",
     "tslint": "^5.11.0",
     "tslint-config-airbnb": "^5.1.2",
     "typescript": "^3.0.3"

--- a/package.json
+++ b/package.json
@@ -21,10 +21,13 @@
     "prepublishOnly": "npm run test && npm run build"
   },
   "devDependencies": {
+    "@types/benchmark": "^1.0.31",
     "@types/jest": "^23.3.2",
     "@types/node": "^10.12.0",
     "@types/pngjs": "^3.3.0",
+    "benchmark": "^2.1.4",
     "jest": "^23.6.0",
+    "microtime": "^2.1.8",
     "pngjs": "^3.3.3",
     "ts-jest": "^23.1.4",
     "tslint": "^5.11.0",

--- a/src/BufferCursor.ts
+++ b/src/BufferCursor.ts
@@ -1,13 +1,13 @@
 export default class BufferCursor {
   private p = 0;
-  private typedBuffer: Uint8Array;
+  array: Uint8Array;
 
   constructor(public length: number) {
-    this.typedBuffer = new Uint8Array(length);
+    this.array = new Uint8Array(length);
   }
 
   public get buffer() {
-    return this.typedBuffer.buffer;
+    return this.array.buffer;
   }
 
   public seek(offset: number) {
@@ -23,7 +23,7 @@ export default class BufferCursor {
   }
 
   public writeArray(arr: Uint8Array) {
-    this.typedBuffer.set(arr, this.p);
+    this.array.set(arr, this.p);
     this.p += arr.length;
   }
 }

--- a/src/BufferCursor.ts
+++ b/src/BufferCursor.ts
@@ -1,11 +1,13 @@
 export default class BufferCursor {
   private p = 0;
-  private view: DataView;
-  public buffer: ArrayBuffer;
+  private typedBuffer: Uint8Array;
 
   constructor(public length: number) {
-    this.buffer = new ArrayBuffer(length);
-    this.view = new DataView(this.buffer);
+    this.typedBuffer = new Uint8Array(length);
+  }
+
+  public get buffer() {
+    return this.typedBuffer.buffer;
   }
 
   public seek(offset: number) {
@@ -20,17 +22,8 @@ export default class BufferCursor {
     return this.buffer.slice(from, to);
   }
 
-  public writeUInt8Array(arr: number[] | Uint8Array) {
-    for (const byte of arr) {
-      this.view.setUint8(this.p, byte);
-      this.p += 1;
-    }
-  }
-
-  public writeUInt32LEArray(arr: number[] | Uint32Array) {
-    for (const val of arr) {
-      this.view.setUint32(this.p, val, true);
-      this.p += 4;
-    }
+  public writeArray(arr: Uint8Array) {
+    this.typedBuffer.set(arr, this.p);
+    this.p += arr.length;
   }
 }

--- a/src/RunLengthEncoder.ts
+++ b/src/RunLengthEncoder.ts
@@ -1,8 +1,8 @@
 import BufferCursor from './BufferCursor';
 import { Pixel } from './types';
 
-function comparePixel(a?: Pixel, b?: Pixel) {
-  if (!a || !b) return false;
+function comparePixel(a: Pixel, b: Pixel) {
+  if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i += 1) {
     if (a[i] !== b[i]) return false;
   }
@@ -20,7 +20,7 @@ export default class RunLengthEncoder {
   private headerIndex: number;
   private willCompress = false;
 
-  constructor(private destination: BufferCursor, private bytesPerPixel: number) {
+  constructor(private destination: BufferCursor, bytesPerPixel: number) {
     this.headerIndex = this.destination.tell();
     this.lastPixel = new Uint8Array(bytesPerPixel);
   }

--- a/src/RunLengthEncoder.ts
+++ b/src/RunLengthEncoder.ts
@@ -16,17 +16,15 @@ export default class RunLengthEncoder {
   private pixelCount = 0;
   private sectionIndex = 1;
   private willCompress = false;
-  private section: Uint8ClampedArray;
+  private section: Uint8Array;
 
   constructor(bytesPerPixel: number) {
-    this.section = new Uint8ClampedArray((MAX_SECTION_LENGTH * bytesPerPixel) + 1);
+    this.section = new Uint8Array((MAX_SECTION_LENGTH * bytesPerPixel) + 1);
   }
 
   private writePixelToSection(pixel: Pixel) {
-    for (const byte of pixel) {
-      this.section[this.sectionIndex] = byte;
-      this.sectionIndex += 1;
-    }
+    this.section.set(pixel, this.sectionIndex);
+    this.sectionIndex += pixel.length;
     this.pixelCount += 1;
   }
 
@@ -44,7 +42,7 @@ export default class RunLengthEncoder {
   private internalFlush() {
     let out = null;
     if (this.pixelCount > 0) {
-      out = new Uint8Array(this.section.slice(0, this.sectionIndex));
+      out = new Uint8Array(this.section.subarray(0, this.sectionIndex));
       out[0] = this.willCompress ? (MAX_SECTION_LENGTH + 1) : 0;
       out[0] |= this.pixelCount & MAX_SECTION_LENGTH;
     }
@@ -68,7 +66,7 @@ export default class RunLengthEncoder {
       } else {
         out = this.internalFlush();
         this.willCompress = false;
-        this.lastPixel = pixel;
+        this.lastPixel = new Uint8Array(pixel);
       }
     } else if (this.lastPixel && comparePixel(pixel, this.lastPixel)) {
       out = this.internalFlush();
@@ -80,7 +78,7 @@ export default class RunLengthEncoder {
       if (this.lastPixel) this.writePixelToSection(this.lastPixel);
       if (this.isSectionFull) out = this.internalFlush();
 
-      this.lastPixel = pixel;
+      this.lastPixel = new Uint8Array(pixel);
     }
     return out;
   }

--- a/src/RunLengthEncoder.ts
+++ b/src/RunLengthEncoder.ts
@@ -25,9 +25,9 @@ export default class RunLengthEncoder {
     this.lastPixel = new Uint8Array(bytesPerPixel);
   }
 
-  private writePixelToSection(pixel: Pixel) {
+  private writePixelToSection() {
     if (this.pixelCount === 0) this.destination.seek(this.headerIndex + 1);
-    this.destination.writeArray(pixel);
+    this.destination.writeArray(this.lastPixel);
     this.pixelCount += 1;
   }
 
@@ -42,7 +42,7 @@ export default class RunLengthEncoder {
 
   flush() {
     if (!this.willCompress && this.lastPixelValid) {
-      this.writePixelToSection(this.lastPixel);
+      this.writePixelToSection();
     }
     return this.internalFlush();
   }
@@ -75,10 +75,10 @@ export default class RunLengthEncoder {
     } else if (this.lastPixelValid && comparePixel(pixel, this.lastPixel)) {
       this.internalFlush();
       this.willCompress = true;
-      this.writePixelToSection(this.lastPixel);
+      this.writePixelToSection();
       this.pixelCount = 2;
     } else {
-      if (this.lastPixelValid) this.writePixelToSection(this.lastPixel);
+      if (this.lastPixelValid) this.writePixelToSection();
       if (this.isSectionFull) this.internalFlush();
 
       this.setLastPixel(pixel);

--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -20,7 +20,7 @@ const TXI_HEADER_LENGTH = 40;
 const INPUT_FORMAT_BPP = 4;
 
 function rescaleColor(value: number, newMax: number) {
-  return Math.round(value / 255 * newMax);
+  return ((value * newMax + 127) / 255) | 0;
 }
 
 const textureBPP: { [format: number]: number } = {
@@ -59,7 +59,9 @@ const pixelEncoders: { [format: number]: PixelEncoder } = {
   },
   [TextureFormat.ABGR6666]: (data, offset, output) => {
     if (data[offset + 3] === 0) {
-      output.fill(0);
+      output[0] = 0;
+      output[1] = 0;
+      output[2] = 0;
       return;
     }
 

--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -23,6 +23,7 @@ function rescaleColor(value: number, newMax: number) {
   return ((value * newMax + 127) / 255) | 0;
 }
 
+// BPP = bytes per pixel
 const textureBPP: { [format: number]: number } = {
   [TextureFormat.A8]: 1,
   [TextureFormat.BGRA8888]: 4,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type Pixel = number[];
+export type Pixel = Uint8Array;
 
 export interface ImageData {
   width: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -173,7 +173,7 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
 
-arrify@^1.0.1:
+arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
@@ -467,7 +467,7 @@ buffer-fill@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
 
-buffer-from@^1.0.0:
+buffer-from@^1.0.0, buffer-from@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
 
@@ -742,7 +742,7 @@ detect-newline@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
 
-diff@^3.2.0:
+diff@^3.1.0, diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
@@ -2005,6 +2005,11 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+make-error@^1.1.1:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
+  integrity sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -3155,6 +3160,20 @@ ts-jest@^23.1.4:
     json5 "^0.5.0"
     lodash "^4.17.10"
 
+ts-node@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.1.tgz#9562dc2d1e6d248d24bc55f773e3f614337d9baf"
+  integrity sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==
+  dependencies:
+    arrify "^1.0.0"
+    buffer-from "^1.1.0"
+    diff "^3.1.0"
+    make-error "^1.1.1"
+    minimist "^1.2.0"
+    mkdirp "^0.5.1"
+    source-map-support "^0.5.6"
+    yn "^2.0.0"
+
 tslib@1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
@@ -3457,3 +3476,8 @@ yargs@^11.0.0:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
+
+yn@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
+  integrity sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,6 +33,10 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
+"@types/benchmark@^1.0.31":
+  version "1.0.31"
+  resolved "https://registry.yarnpkg.com/@types/benchmark/-/benchmark-1.0.31.tgz#2dd3514e93396f362ba5551a7c9ff0da405c1d38"
+
 "@types/jest@^23.3.2":
   version "23.3.2"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.2.tgz#07b90f6adf75d42c34230c026a2529e56c249dbb"
@@ -384,6 +388,24 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+benchmark@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/benchmark/-/benchmark-2.1.4.tgz#09f3de31c916425d498cc2ee565a0ebf3c2a5629"
+  dependencies:
+    lodash "^4.17.4"
+    platform "^1.3.3"
+
+bindings@1.3.x:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
+
+bl@^1.0.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.2.tgz#a160911717103c07410cef63ef51b397c025af9c"
+  dependencies:
+    readable-stream "^2.3.5"
+    safe-buffer "^5.1.1"
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -429,6 +451,21 @@ bser@^2.0.0:
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
   dependencies:
     node-int64 "^0.4.0"
+
+buffer-alloc-unsafe@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
+
+buffer-alloc@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
+  dependencies:
+    buffer-alloc-unsafe "^1.1.0"
+    buffer-fill "^1.0.0"
+
+buffer-fill@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -638,6 +675,12 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
 
+decompress-response@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
+  dependencies:
+    mimic-response "^1.0.0"
+
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
@@ -691,7 +734,7 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
-detect-libc@^1.0.2:
+detect-libc@^1.0.2, detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
 
@@ -722,6 +765,12 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+end-of-stream@^1.0.0, end-of-stream@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
+  dependencies:
+    once "^1.4.0"
 
 error-ex@^1.2.0:
   version "1.3.2"
@@ -827,6 +876,10 @@ expand-range@^1.8.1:
   resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
   dependencies:
     fill-range "^2.1.0"
+
+expand-template@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-1.1.1.tgz#981f188c0c3a87d2e28f559bc541426ff94f21dd"
 
 expect@^23.6.0:
   version "23.6.0"
@@ -972,6 +1025,10 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+
 fs-extra@6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
@@ -1031,6 +1088,10 @@ getpass@^0.1.1:
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
   dependencies:
     assert-plus "^1.0.0"
+
+github-from-package@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -2016,6 +2077,14 @@ micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
+microtime@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/microtime/-/microtime-2.1.8.tgz#b43c4c5ab13e527e173370d0306d9e0a4bbf410d"
+  dependencies:
+    bindings "1.3.x"
+    nan "2.10.x"
+    prebuild-install "^2.1.0"
+
 mime-db@~1.36.0:
   version "1.36.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.36.0.tgz#5020478db3c7fe93aad7bbcc4dcf869c43363397"
@@ -2029,6 +2098,10 @@ mime-types@^2.1.12, mime-types@~2.1.19:
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
+
+mimic-response@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
 
 minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
@@ -2082,6 +2155,10 @@ ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
+nan@2.10.x:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
+
 nan@^2.9.2:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.0.tgz#574e360e4d954ab16966ec102c0c049fd961a099"
@@ -2114,6 +2191,12 @@ needle@^2.2.1:
     iconv-lite "^0.4.4"
     sax "^1.2.4"
 
+node-abi@^2.2.0:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.4.5.tgz#1fd1fb66641bf3c4dcf55a5490ba10c467ead80c"
+  dependencies:
+    semver "^5.4.1"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -2141,6 +2224,10 @@ node-pre-gyp@^0.10.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
+
+noop-logger@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -2181,7 +2268,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npmlog@^4.0.2:
+npmlog@^4.0.1, npmlog@^4.0.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   dependencies:
@@ -2244,7 +2331,7 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-once@^1.3.0, once@^1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
@@ -2268,7 +2355,7 @@ optionator@^0.8.1:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
-os-homedir@^1.0.0:
+os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
@@ -2388,6 +2475,10 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+platform@^1.3.3:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.5.tgz#fb6958c696e07e2918d2eeda0f0bc9448d733444"
+
 pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
@@ -2399,6 +2490,26 @@ pngjs@^3.3.3:
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
+
+prebuild-install@^2.1.0:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-2.5.3.tgz#9f65f242782d370296353710e9bc843490c19f69"
+  dependencies:
+    detect-libc "^1.0.3"
+    expand-template "^1.0.2"
+    github-from-package "0.0.0"
+    minimist "^1.2.0"
+    mkdirp "^0.5.1"
+    node-abi "^2.2.0"
+    noop-logger "^0.1.1"
+    npmlog "^4.0.1"
+    os-homedir "^1.0.1"
+    pump "^2.0.1"
+    rc "^1.1.6"
+    simple-get "^2.7.0"
+    tar-fs "^1.13.0"
+    tunnel-agent "^0.6.0"
+    which-pm-runs "^1.0.0"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -2438,6 +2549,20 @@ psl@^1.1.24:
   version "1.1.29"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
 
+pump@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-1.0.3.tgz#5dfe8311c33bbf6fc18261f9f34702c47c08a954"
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
+pump@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -2458,7 +2583,7 @@ randomatic@^3.0.0:
     kind-of "^6.0.0"
     math-random "^1.0.1"
 
-rc@^1.2.7:
+rc@^1.1.6, rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   dependencies:
@@ -2482,7 +2607,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-readable-stream@^2.0.1, readable-stream@^2.0.6:
+readable-stream@^2.0.1, readable-stream@^2.0.6, readable-stream@^2.3.0, readable-stream@^2.3.5:
   version "2.3.6"
   resolved "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -2624,7 +2749,7 @@ rsvp@^3.3.3:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 
@@ -2700,6 +2825,18 @@ shellwords@^0.1.1:
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+simple-concat@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.0.tgz#7344cbb8b6e26fb27d66b2fc86f9f6d5997521c6"
+
+simple-get@^2.7.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-2.8.1.tgz#0e22e91d4575d87620620bc91308d57a77f44b5d"
+  dependencies:
+    decompress-response "^3.3.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
 
 sisteransi@^0.1.1:
   version "0.1.1"
@@ -2911,6 +3048,27 @@ symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
+tar-fs@^1.13.0:
+  version "1.16.3"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-1.16.3.tgz#966a628841da2c4010406a82167cbd5e0c72d509"
+  dependencies:
+    chownr "^1.0.1"
+    mkdirp "^0.5.1"
+    pump "^1.0.0"
+    tar-stream "^1.1.2"
+
+tar-stream@^1.1.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.2.tgz#8ea55dab37972253d9a9af90fdcd559ae435c555"
+  dependencies:
+    bl "^1.0.0"
+    buffer-alloc "^1.2.0"
+    end-of-stream "^1.0.0"
+    fs-constants "^1.0.0"
+    readable-stream "^2.3.0"
+    to-buffer "^1.1.1"
+    xtend "^4.0.0"
+
 tar@^4:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.6.tgz#63110f09c00b4e60ac8bcfe1bf3c8660235fbc9b"
@@ -2940,6 +3098,10 @@ throat@^4.0.0:
 tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
+
+to-buffer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.1.1.tgz#493bd48f62d7c43fcded313a03dcadb2e1213a80"
 
 to-fast-properties@^1.0.3:
   version "1.0.3"
@@ -3204,6 +3366,10 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
+which-pm-runs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
+
 which@^1.2.12, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -3252,6 +3418,10 @@ ws@^5.2.0:
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
+
+xtend@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
Profiled and tweaked the encoder to improve performance. As an example, My Cat Inca takes approximately 70s to build without this change and around 12.5s with it.